### PR TITLE
feat: implement dynamic cache tags

### DIFF
--- a/storefront/src/lib/data/cart.ts
+++ b/storefront/src/lib/data/cart.ts
@@ -6,7 +6,14 @@ import { HttpTypes } from "@medusajs/types"
 import { omit } from "lodash"
 import { revalidateTag } from "next/cache"
 import { redirect } from "next/navigation"
-import { getAuthHeaders, getCartId, removeCartId, setCartId } from "./cookies"
+import {
+  getAuthHeaders,
+  getCacheHeaders,
+  getCacheTag,
+  getCartId,
+  removeCartId,
+  setCartId,
+} from "./cookies"
 import { getProductsById } from "./products"
 import { getRegion } from "./regions"
 
@@ -24,7 +31,7 @@ export async function retrieveCart() {
         fields:
           "+items, +region, +items.product.*, +items.variant.*, +items.thumbnail",
       },
-      { next: { tags: [`cart-${cartId}`] }, ...getAuthHeaders() }
+      { ...getAuthHeaders(), ...getCacheHeaders("carts") }
     )
     .then(({ cart }) => cart)
     .catch(() => {
@@ -44,7 +51,7 @@ export async function getOrSetCart(countryCode: string) {
     const cartResp = await sdk.store.cart.create({ region_id: region.id })
     cart = cartResp.cart
     setCartId(cart.id)
-    revalidateTag(`cart-${cart.id}`)
+    revalidateTag(getCacheTag("carts"))
   }
 
   if (cart && cart?.region_id !== region.id) {
@@ -54,7 +61,7 @@ export async function getOrSetCart(countryCode: string) {
       {},
       getAuthHeaders()
     )
-    revalidateTag(`cart-${cart.id}`)
+    revalidateTag(getCacheTag("carts"))
   }
 
   return cart
@@ -69,7 +76,7 @@ export async function updateCart(data: HttpTypes.StoreUpdateCart) {
   return sdk.store.cart
     .update(cartId, data, {}, getAuthHeaders())
     .then(({ cart }) => {
-      revalidateTag(`cart-${cart.id}`)
+      revalidateTag(getCacheTag("carts"))
       return cart
     })
     .catch(medusaError)
@@ -104,7 +111,7 @@ export async function addToCart({
       getAuthHeaders()
     )
     .then(() => {
-      revalidateTag(`cart-${cart.id}`)
+      revalidateTag(getCacheTag("carts"))
     })
     .catch(medusaError)
 }
@@ -128,7 +135,7 @@ export async function updateLineItem({
   await sdk.store.cart
     .updateLineItem(cartId, lineId, { quantity }, {}, getAuthHeaders())
     .then(() => {
-      revalidateTag(`cart-${cartId}`)
+      revalidateTag(getCacheTag("carts"))
     })
     .catch(medusaError)
 }
@@ -146,7 +153,7 @@ export async function deleteLineItem(lineId: string) {
   await sdk.store.cart
     .deleteLineItem(cartId, lineId, getAuthHeaders())
     .then(() => {
-      revalidateTag(`cart-${cartId}`)
+      revalidateTag(getCacheTag("carts"))
     })
     .catch(medusaError)
 }
@@ -213,7 +220,7 @@ export async function setShippingMethod({
       getAuthHeaders()
     )
     .then(() => {
-      revalidateTag(`cart-${cartId}`)
+      revalidateTag(getCacheTag("carts"))
     })
     .catch(medusaError)
 }
@@ -228,7 +235,7 @@ export async function initiatePaymentSession(
   return sdk.store.payment
     .initiatePaymentSession(cart, data, {}, getAuthHeaders())
     .then((resp) => {
-      revalidateTag(`cart-${cart.id}`)
+      revalidateTag(getCacheTag("carts"))
       return resp
     })
     .catch(medusaError)
@@ -242,7 +249,7 @@ export async function applyPromotions(codes: string[]) {
 
   await updateCart({ promo_codes: codes })
     .then(() => {
-      revalidateTag(`cart-${cartId}`)
+      revalidateTag(getCacheTag("carts"))
     })
     .catch(medusaError)
 }
@@ -252,7 +259,7 @@ export async function applyGiftCard(code: string) {
   //   if (!cartId) return "No cartId cookie found"
   //   try {
   //     await updateCart(cartId, { gift_cards: [{ code }] }).then(() => {
-  //       revalidateTag("cart")
+  //       revalidateTag(getCacheTag("carts"))
   //     })
   //   } catch (error: any) {
   //     throw error
@@ -264,7 +271,7 @@ export async function removeDiscount(code: string) {
   // if (!cartId) return "No cartId cookie found"
   // try {
   //   await deleteDiscount(cartId, code)
-  //   revalidateTag("cart")
+  //   revalidateTag(getCacheTag("carts"))
   // } catch (error: any) {
   //   throw error
   // }
@@ -283,7 +290,7 @@ export async function removeGiftCard(
   //         .filter((gc) => gc.code !== codeToRemove)
   //         .map((gc) => ({ code: gc.code })),
   //     }).then(() => {
-  //       revalidateTag("cart")
+  //       revalidateTag(getCacheTag("carts"))
   //     })
   //   } catch (error: any) {
   //     throw error
@@ -364,7 +371,7 @@ export async function placeOrder() {
   const cartRes = await sdk.store.cart
     .complete(cartId, {}, getAuthHeaders())
     .then((cartRes) => {
-      revalidateTag(`cart-${cartId}`)
+      revalidateTag(getCacheTag("carts"))
       return cartRes
     })
     .catch(medusaError)
@@ -394,11 +401,11 @@ export async function updateRegion(countryCode: string, currentPath: string) {
 
   if (cartId) {
     await updateCart({ region_id: region.id })
-    revalidateTag(`cart-${cartId}`)
+    revalidateTag(getCacheTag("carts"))
   }
 
-  revalidateTag("regions")
-  revalidateTag("products")
+  revalidateTag(getCacheTag("regions"))
+  revalidateTag(getCacheTag("products"))
 
   redirect(`/${countryCode}${currentPath}`)
 }

--- a/storefront/src/lib/data/categories.ts
+++ b/storefront/src/lib/data/categories.ts
@@ -1,9 +1,13 @@
 import { sdk } from "@lib/config"
 import { cache } from "react"
+import { getCacheHeaders } from "./cookies"
 
 export const listCategories = cache(async function () {
   return sdk.store.category
-    .list({ fields: "+category_children" }, { next: { tags: ["categories"] } })
+    .list(
+      { fields: "+category_children" },
+      { ...getCacheHeaders("categories") }
+    )
     .then(({ product_categories }) => product_categories)
 })
 
@@ -15,18 +19,17 @@ export const getCategoriesList = cache(async function (
     // TODO: Look into fixing the type
     // @ts-ignore
     { limit, offset },
-    { next: { tags: ["categories"] } }
+    { ...getCacheHeaders("categories") }
   )
 })
 
 export const getCategoryByHandle = cache(async function (
   categoryHandle: string[]
 ) {
-
   return sdk.store.category.list(
     // TODO: Look into fixing the type
     // @ts-ignore
     { handle: categoryHandle },
-    { next: { tags: ["categories"] } }
+    { ...getCacheHeaders("categories") }
   )
 })

--- a/storefront/src/lib/data/collections.ts
+++ b/storefront/src/lib/data/collections.ts
@@ -2,10 +2,11 @@ import { sdk } from "@lib/config"
 import { cache } from "react"
 import { getProductsList } from "./products"
 import { HttpTypes } from "@medusajs/types"
+import { getCacheHeaders } from "./cookies"
 
 export const retrieveCollection = cache(async function (id: string) {
   return sdk.store.collection
-    .retrieve(id, {}, { next: { tags: ["collections"] } })
+    .retrieve(id, {}, { ...getCacheHeaders("collections") })
     .then(({ collection }) => collection)
 })
 
@@ -14,7 +15,7 @@ export const getCollectionsList = cache(async function (
   limit: number = 100
 ): Promise<{ collections: HttpTypes.StoreCollection[]; count: number }> {
   return sdk.store.collection
-    .list({ limit, offset: 0 }, { next: { tags: ["collections"] } })
+    .list({ limit, offset: 0 }, { ...getCacheHeaders("collections") })
     .then(({ collections }) => ({ collections, count: collections.length }))
 })
 
@@ -22,7 +23,7 @@ export const getCollectionByHandle = cache(async function (
   handle: string
 ): Promise<HttpTypes.StoreCollection> {
   return sdk.store.collection
-    .list({ handle }, { next: { tags: ["collections"] } })
+    .list({ handle }, { ...getCacheHeaders("collections") })
     .then(({ collections }) => collections[0])
 })
 

--- a/storefront/src/lib/data/cookies.ts
+++ b/storefront/src/lib/data/cookies.ts
@@ -11,6 +11,11 @@ export const getAuthHeaders = (): { authorization: string } | {} => {
   return {}
 }
 
+export const getCacheTag = (tag: string) => {
+  const cacheId = cookies().get("_medusa_cache_id")?.value
+  return { tags: [`${tag}-${cacheId}`] }
+}
+
 export const setAuthToken = (token: string) => {
   cookies().set("_medusa_jwt", token, {
     maxAge: 60 * 60 * 24 * 7,

--- a/storefront/src/lib/data/cookies.ts
+++ b/storefront/src/lib/data/cookies.ts
@@ -11,9 +11,26 @@ export const getAuthHeaders = (): { authorization: string } | {} => {
   return {}
 }
 
-export const getCacheTag = (tag: string) => {
+export const getCacheTag = (tag: string): string => {
   const cacheId = cookies().get("_medusa_cache_id")?.value
-  return { tags: [`${tag}-${cacheId}`] }
+
+  if (cacheId) {
+    return `${tag}-${cacheId}`
+  }
+
+  return ""
+}
+
+export const getCacheHeaders = (
+  tag: string
+): { next: { tags: string[] } } | {} => {
+  const cacheTag = getCacheTag(tag)
+
+  if (cacheTag) {
+    return { next: { tags: [`${cacheTag}`] } }
+  }
+
+  return {}
 }
 
 export const setAuthToken = (token: string) => {

--- a/storefront/src/lib/data/fulfillment.ts
+++ b/storefront/src/lib/data/fulfillment.ts
@@ -1,10 +1,11 @@
 import { sdk } from "@lib/config"
 import { cache } from "react"
+import { getCacheHeaders } from "./cookies"
 
 // Shipping actions
 export const listCartShippingMethods = cache(async function (cartId: string) {
   return sdk.store.fulfillment
-    .listCartOptions({ cart_id: cartId }, { next: { tags: ["shipping"] } })
+    .listCartOptions({ cart_id: cartId }, { ...getCacheHeaders("fulfillment") })
     .then(({ shipping_options }) => shipping_options)
     .catch(() => {
       return null

--- a/storefront/src/lib/data/orders.ts
+++ b/storefront/src/lib/data/orders.ts
@@ -3,14 +3,14 @@
 import { sdk } from "@lib/config"
 import medusaError from "@lib/util/medusa-error"
 import { cache } from "react"
-import { getAuthHeaders } from "./cookies"
+import { getAuthHeaders, getCacheHeaders } from "./cookies"
 
 export const retrieveOrder = cache(async function (id: string) {
   return sdk.store.order
     .retrieve(
       id,
       { fields: "*payment_collections.payments" },
-      { next: { tags: ["order"] }, ...getAuthHeaders() }
+      { ...getCacheHeaders("orders"), ...getAuthHeaders() }
     )
     .then(({ order }) => order)
     .catch((err) => medusaError(err))
@@ -21,7 +21,10 @@ export const listOrders = cache(async function (
   offset: number = 0
 ) {
   return sdk.store.order
-    .list({ limit, offset }, { next: { tags: ["order"] }, ...getAuthHeaders() })
+    .list(
+      { limit, offset },
+      { ...getCacheHeaders("orders"), ...getAuthHeaders() }
+    )
     .then(({ orders }) => orders)
     .catch((err) => medusaError(err))
 })

--- a/storefront/src/lib/data/payment.ts
+++ b/storefront/src/lib/data/payment.ts
@@ -1,12 +1,13 @@
 import { sdk } from "@lib/config"
 import { cache } from "react"
+import { getCacheHeaders } from "./cookies"
 
 // Shipping actions
 export const listCartPaymentMethods = cache(async function (regionId: string) {
   return sdk.store.payment
     .listPaymentProviders(
       { region_id: regionId },
-      { next: { tags: ["payment_providers"] } }
+      { ...getCacheHeaders("payment_providers") }
     )
     .then(({ payment_providers }) => payment_providers)
     .catch(() => {

--- a/storefront/src/lib/data/products.ts
+++ b/storefront/src/lib/data/products.ts
@@ -4,6 +4,7 @@ import { cache } from "react"
 import { getRegion } from "./regions"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
 import { sortProducts } from "@lib/util/sort-products"
+import { getCacheHeaders } from "./cookies"
 
 export const getProductsById = cache(async function ({
   ids,
@@ -20,7 +21,7 @@ export const getProductsById = cache(async function ({
         fields:
           "*variants.calculated_price,+variants.inventory_quantity,+inventory_quantity",
       },
-      { next: { tags: ["products"] } }
+      { ...getCacheHeaders("products") }
     )
     .then(({ products }) => products)
 })
@@ -36,7 +37,7 @@ export const getProductByHandle = cache(async function (
         region_id: regionId,
         fields: "*variants.calculated_price,+variants.inventory_quantity",
       },
-      { next: { tags: ["products"] } }
+      { ...getCacheHeaders("products") }
     )
     .then(({ products }) => products[0])
 })
@@ -73,7 +74,7 @@ export const getProductsList = cache(async function ({
         fields: "*variants.calculated_price",
         ...queryParams,
       },
-      { next: { tags: ["products"] } }
+      { ...getCacheHeaders("products") }
     )
     .then(({ products, count }) => {
       const nextPage = count > offset + limit ? pageParam + 1 : null

--- a/storefront/src/lib/data/regions.ts
+++ b/storefront/src/lib/data/regions.ts
@@ -2,17 +2,18 @@ import { sdk } from "@lib/config"
 import medusaError from "@lib/util/medusa-error"
 import { cache } from "react"
 import { HttpTypes } from "@medusajs/types"
+import { getCacheHeaders } from "./cookies"
 
 export const listRegions = cache(async function () {
   return sdk.store.region
-    .list({}, { next: { tags: ["regions"] } })
+    .list({}, { ...getCacheHeaders("regions") })
     .then(({ regions }) => regions)
     .catch(medusaError)
 })
 
 export const retrieveRegion = cache(async function (id: string) {
   return sdk.store.region
-    .retrieve(id, {}, { next: { tags: ["regions"] } })
+    .retrieve(id, {}, { ...getCacheHeaders("regions") })
     .then(({ region }) => region)
     .catch(medusaError)
 })


### PR DESCRIPTION
Implements dynamic cache tags throughout the storefront. This ensures that the cache will be invalidated for the current client only when server data mutates.

- Added some logic to Nextjs middleware that generates a unique id and sets it in a `_medusa_cache_id` cookie.
- Added a `getCacheTag()` helper function which takes in a string input. This will return a dynamic cache tag string in the format `{input}-{_medusa_cache_id}`. This is useful when revalidating tags after performing a mutation.
- Added a `getCacheHeaders()` helper function which takes in a string input. This will return the `next: {}` headers to assign a dynamic cache tag to a GET request.