### PR TITLE
chore: git clone via https

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@
 
 ```bash
 # Clone the repository
-git clone git@github.com:medusajs/b2b-starter-medusa.git
+git clone https://github.com/medusajs/b2b-starter-medusa.git
 
 # Go to the folder
 cd ./b2b-starter-medusa


### PR DESCRIPTION
This pull request simplifies the process of cloning the repository and fixes an issue where some users get a public key error when using SSH.

```
nikohann@Nikos-Air medusa % git clone git@github.com:medusajs/b2b-starter-medusa.git
Cloning into 'b2b-starter-medusa'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights and the repository exists.
```