### PR TITLE
fix: rm spend limit division

### DIFF
--- a/apps/backend/src/admin/components/employees/employees-create-form.tsx
+++ b/apps/backend/src/admin/components/employees/employees-create-form.tsx
@@ -56,7 +56,7 @@ export function EmployeesCreateForm({
     e.preventDefault();
 
     const spendingLimit = formData.spending_limit
-      ? parseInt(formData.spending_limit) * 100
+      ? parseInt(formData.spending_limit)
       : 0;
 
     const data = {

--- a/apps/backend/src/admin/components/employees/employees-update-form.tsx
+++ b/apps/backend/src/admin/components/employees/employees-update-form.tsx
@@ -30,7 +30,7 @@ export function EmployeesUpdateForm({
     spending_limit: string;
     is_admin: boolean;
   }>({
-    spending_limit: (employee?.spending_limit / 100).toString() || "0",
+    spending_limit: employee?.spending_limit?.toString() || "0",
     is_admin: employee?.is_admin || false,
   });
 
@@ -38,7 +38,7 @@ export function EmployeesUpdateForm({
     e.preventDefault();
 
     const spendingLimit = formData.spending_limit
-      ? Number(formData.spending_limit) * 100
+      ? Number(formData.spending_limit)
       : undefined;
 
     const data = {

--- a/apps/backend/src/admin/routes/companies/[companyId]/page.tsx
+++ b/apps/backend/src/admin/routes/companies/[companyId]/page.tsx
@@ -144,7 +144,7 @@ const CompanyDetails = () => {
                       <Table.Cell>{employee.customer?.email}</Table.Cell>
                       <Table.Cell>
                         {formatAmount(
-                          employee.spending_limit / 100,
+                          employee.spending_limit,
                           company?.currency_code || "USD"
                         )}
                       </Table.Cell>

--- a/apps/backend/src/api/admin/companies/[id]/employees/[employeeId]/route.ts
+++ b/apps/backend/src/api/admin/companies/[id]/employees/[employeeId]/route.ts
@@ -24,7 +24,7 @@ export const GET = async (
   } = await query.graph(
     {
       entity: "employee",
-      fields: req.remoteQueryConfig.fields,
+      fields: req.remoteQueryConfig?.fields,
       filters: { ...req.filterableFields, id: employeeId, company_id: id },
     },
     { throwIfKeyNotFound: true }
@@ -56,7 +56,7 @@ export const POST = async (
   } = await query.graph(
     {
       entity: "employee",
-      fields: req.remoteQueryConfig.fields,
+      fields: req.remoteQueryConfig?.fields,
       filters: { ...req.filterableFields, id: employeeId, company_id: id },
     },
     { throwIfKeyNotFound: true }

--- a/apps/storefront/src/lib/util/check-spending-limit.ts
+++ b/apps/storefront/src/lib/util/check-spending-limit.ts
@@ -54,7 +54,7 @@ export function checkSpendingLimit(
     return false
   }
 
-  const spendingLimit = customer.employee.spending_limit / 100
+  const spendingLimit = customer.employee.spending_limit
   const spendWindow = getSpendWindow(customer.employee.company)
   const spent = getOrderTotalInSpendWindow(customer.orders || [], spendWindow)
 

--- a/apps/storefront/src/lib/util/convert-cart-to-csv.ts
+++ b/apps/storefront/src/lib/util/convert-cart-to-csv.ts
@@ -10,7 +10,7 @@ export function cartToCsv(cart: B2BCart) {
     items?.map((item: HttpTypes.StoreCartLineItem) => {
       const taxRate = item.tax_lines?.[0]?.rate || 0
       const totalPrice = item.quantity * item.unit_price
-      const totalTax = (totalPrice * taxRate) / 100
+      const totalTax = totalPrice * taxRate
 
       return {
         id: item.id,

--- a/apps/storefront/src/modules/account/components/employees-card/employee.tsx
+++ b/apps/storefront/src/modules/account/components/employees-card/employee.tsx
@@ -78,7 +78,7 @@ const Employee = ({
   const [employeeData, setEmployeeData] = useState({
     id: employee.id,
     company_id: employee.company_id,
-    spending_limit: (employee.spending_limit / 100).toString(),
+    spending_limit: employee.spending_limit.toString(),
     is_admin: employee.is_admin,
   })
 
@@ -87,7 +87,7 @@ const Employee = ({
   const handleSubmit = async () => {
     const updateData = {
       ...employeeData,
-      spending_limit: parseFloat(employeeData.spending_limit) * 100,
+      spending_limit: parseFloat(employeeData.spending_limit),
     }
 
     setIsSaving(true)


### PR DESCRIPTION
This pull request includes several changes to how spending limits are handled across different parts of the codebase, specifically removing the multiplication and division by 100 to simplify the calculations.

Changes to spending limit calculations:

* [`apps/backend/src/admin/components/employees/employees-create-form.tsx`](diffhunk://#diff-3fcc1eff7f449c243006ab42f3c1bc2db62c07f724e44c20aa8e4613b66b8c62L59-R59): Removed the multiplication by 100 when parsing `spending_limit` in the `EmployeesCreateForm` component.
* [`apps/backend/src/admin/components/employees/employees-update-form.tsx`](diffhunk://#diff-68c32d2efc9b800b52c17552ddf5372d04b52d2fd5cc59e54e2e7ed0a6df24eaL33-R41): Removed the multiplication by 100 when parsing `spending_limit` in the `EmployeesUpdateForm` component.
* `apps/backend/src/admin/routes/companies/[companyId]/page.tsx`: Updated the `CompanyDetails` component to remove the division by 100 when formatting `spending_limit`. ([apps/backend/src/admin/routes/companies/[companyId]/page.tsxL147-R147](diffhunk://#diff-bdfeed1be332de8dd9f916086e9cdc8b6bc8c74e6fb97e8e7b1b3de65acc213fL147-R147))
* [`apps/storefront/src/lib/util/check-spending-limit.ts`](diffhunk://#diff-dee3b2ff42ede6a13a32a6ac2f30bbfff863bc62514d02190933419e038fd533L57-R57): Removed the division by 100 in the `checkSpendingLimit` function.
* [`apps/storefront/src/lib/util/convert-cart-to-csv.ts`](diffhunk://#diff-79631929cc37717ae69c8b5ead1b877b80efedbccae8807cb054a1d691545eebL13-R13): Removed the division by 100 when calculating `totalTax` in the `cartToCsv` function.
* [`apps/storefront/src/modules/account/components/employees-card/employee.tsx`](diffhunk://#diff-7345cfae327e33e37a0b6746016ae1ff43dcd22f70415b3591d97c3f924a8273L81-R81): Updated the `Employee` component to remove the division by 100 when setting `spending_limit` and the multiplication by 100 when submitting the form. [[1]](diffhunk://#diff-7345cfae327e33e37a0b6746016ae1ff43dcd22f70415b3591d97c3f924a8273L81-R81) [[2]](diffhunk://#diff-7345cfae327e33e37a0b6746016ae1ff43dcd22f70415b3591d97c3f924a8273L90-R90)