### PR TITLE
chore: revert static store page rendering

### DIFF
--- a/apps/storefront/src/app/[countryCode]/(main)/categories/[...category]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/categories/[...category]/page.tsx
@@ -2,8 +2,7 @@ import { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 import { getCategoryByHandle, listCategories } from "@lib/data/categories"
-import { listRegions } from "@lib/data/regions"
-import { StoreProductCategory, StoreRegion } from "@medusajs/types"
+import { StoreProductCategory } from "@medusajs/types"
 import CategoryTemplate from "@modules/categories/templates"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
 
@@ -13,33 +12,6 @@ type Props = {
     sortBy?: SortOptions
     page?: string
   }
-}
-
-export async function generateStaticParams() {
-  const product_categories = await listCategories()
-
-  if (!product_categories) {
-    return []
-  }
-
-  const countryCodes = await listRegions().then((regions: StoreRegion[]) =>
-    regions?.map((r) => r.countries?.map((c) => c.iso_2)).flat()
-  )
-
-  const categoryHandles = product_categories.map(
-    (category: any) => category.handle
-  )
-
-  const staticParams = countryCodes
-    ?.map((countryCode: string | undefined) =>
-      categoryHandles.map((handle: any) => ({
-        countryCode,
-        category: [handle],
-      }))
-    )
-    .flat()
-
-  return staticParams
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/apps/storefront/src/app/[countryCode]/(main)/store/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/store/page.tsx
@@ -19,33 +19,6 @@ type Params = {
   }
 }
 
-export async function generateStaticParams() {
-  const countryCodes = await listRegions().then(
-    (regions) =>
-      regions
-        ?.map((r) => r.countries?.map((c) => c.iso_2))
-        .flat()
-        .filter(Boolean) as string[]
-  )
-
-  if (!countryCodes) {
-    return null
-  }
-
-  const categories = await listCategories()
-
-  const staticParams = countryCodes
-    ?.map((countryCode) =>
-      categories.map((category) => ({
-        countryCode,
-        handle: category.handle,
-      }))
-    )
-    .flat()
-
-  return staticParams
-}
-
 export default async function StorePage({ searchParams, params }: Params) {
   const { sortBy, page } = searchParams
 


### PR DESCRIPTION
fixes the broken category filters